### PR TITLE
Fixes to the ClusterServiceVersion; now working as intended.

### DIFF
--- a/community-operators/akka-cluster-operator/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/akka-cluster-operator/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     categories: Application Runtime
     certified: 'false'
     containerImage: 'lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest'
-    createdAt: 2019-05-30T00:00:00Z
+    createdAt: '2019-06-28T15:23:00Z'
     description: Run Akka Cluster applications on OpenShift.
     repository: https://github.com/lightbend/akka-cluster-operator
     support: 'Lightbend, Inc.'
@@ -91,22 +91,24 @@ spec:
             version: v1
         specDescriptors:
           - description: 'The desired number of pod instances in the Akka Cluster'
-          - displayName: 'Replica Count'
-          - path: replicas
-          - path: template
+            displayName: 'Replica Count'
+            path: replicas
+          - description: 'The template used to form the cluster'
+            displayName: 'Template'
+            path: template
         statusDescriptors:
-          - description: 'The status of the named Akka Cluster'
-          - displayName: 'Akka Cluster Status'
-          - path: cluster
-          - path: lastUpdate
-          - path: managementHost
-          - path: managementPort
-    required:
-      - name: ''
-        displayName: ''
-        kind: ''
-        version: ''
-        description: ''
+          - description: 'Information on the cluster'
+            displayName: 'Cluster'
+            path: cluster
+          - description: 'The last time the status changed"
+            displayName: 'Last Update'
+            path: lastUpdate
+          - description: 'The host of the (host,port) pair used to obtain the cluster status'
+            displayName: 'Management Host'
+            path: managementHost
+          - description: 'The port of the (host,port) pair used to obtain the cluster status'
+            displayName: 'Management Port'
+            path: managementPort
   description: |
     The Akka Cluster Operator allows you to manage applications designed for
     [Akka Cluster](https://doc.akka.io/docs/akka/current/common/cluster.html).
@@ -151,7 +153,7 @@ spec:
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:
-                            fieldPath: metadata.namespace
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
                       - name: POD_NAME
                         valueFrom:
                           fieldRef:
@@ -163,8 +165,8 @@ spec:
                     name: akka-cluster-operator
                     resources: {}
                 serviceAccountName: akka-cluster-operator
-      clusterPermissions: null
-      permissions:
+      permissions: []
+      clusterPermissions:
         - rules:
             - apiGroups:
                 - ""


### PR DESCRIPTION
A number of changes are included in this pull request:
- The 'required' section of the owned crds was redundant; also,
  parsing it would cause a bizarre "couldn't parse plural.group"
  error message
- The description and displayName are required for all the elements
  of specDescriptors and statusDescriptors (they were in the wrong
  place). Also, tried to give informative description strings
- the 'clusterPermissions' section was set to null; it needs to
  be a (possibly empty) array, instead
- the serviceAccount permissions were set in the 'permissions'
  section, which translates to RBAC roleBindings. This is not
  sufficient, since the operator needs to be able to work on
  namespaces other than the one it is deployed to. So, moved
  those definitions to 'clusterPermissions', instead, which
  get translated to clusterRoleBindings when deployed
- The operator was only watching the namespace it was deployed
  into; that prevented it from reacting to the creation of
  AkkaCluster instances in other namespaces, in accordance with
  the OperatorGroup. That is specified in the 'env' section,
  in which the following appeared:
  ```
    env:
    - name: WATCH_NAMESPACE
      valueFrom:
        fieldRef:
          fieldPath: metadata.namespace
  ```
  That needs to be instead:
  ```
    env:
    - name: WATCH_NAMESPACE
      valueFrom:
        fieldRef:
          fieldPath: metadata.annotations['olm.targetNamespaces']
  ```
