### PR TITLE
validation typo fix

### DIFF
--- a/community-operators/akka-cluster-operator/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/akka-cluster-operator/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ spec:
           - description: 'Information on the cluster'
             displayName: 'Cluster'
             path: cluster
-          - description: 'The last time the status changed"
+          - description: 'The last time the status changed'
             displayName: 'Last Update'
             path: lastUpdate
           - description: 'The host of the (host,port) pair used to obtain the cluster status'


### PR DESCRIPTION
This unmatched string is causing validation to fail, preventing pushing. 